### PR TITLE
Update WatermarkFilterLoader.php

### DIFF
--- a/Imagine/Filter/Loader/WatermarkFilterLoader.php
+++ b/Imagine/Filter/Loader/WatermarkFilterLoader.php
@@ -60,7 +60,9 @@ class WatermarkFilterLoader implements LoaderInterface
 
         if ($options['size']) {
             $factor = $options['size'] * min($size->getWidth() / $watermarkSize->getWidth(), $size->getHeight() / $watermarkSize->getHeight());
-
+            if ($watermarkSize->getWidth() * $factor < 1 || $watermarkSize->getHeight() * $factor < 1){
+               return $image;
+            }
             $watermark->resize(new Box($watermarkSize->getWidth() * $factor, $watermarkSize->getHeight() * $factor));
             $watermarkSize = $watermark->getSize();
         }


### PR DESCRIPTION
fix problem with 1px image in watermarkloader

| Q | A
| --- | ---
| Branch? | 1.0 
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes/no
| Deprecations? | no
| Tests pass? | yes/no
| Fixed tickets | <!-- #-pre-fixed issue number(s), if any -->
| License | MIT
| Doc PR | <!--highly recommended for new features-->

<!--
- Please take a moment to complete the template above by answering
- yes or no to the given questions and providing the bundle version.
-
- Afterward, replace this comment with the description of your PR.
-->

Hi guys!
I have problem in production. Same users load 1px images, after that i cant corrent return thumbnail with Watermark filter for those images(I get Exception in Imagine\Image\Box constructor).Maybe this fix resolve problem? We don't need use water mark if watermark area less 1px by one size.
Thanks!